### PR TITLE
Enforce MKL interface limits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,15 +54,15 @@ jobs:
 
     - name: 🛠 Compile MKL helper
       run: |
-        conda run -n csr python build_mkl.py
+        conda run -n csr --no-capture-output python build_mkl.py
 
     - name: Run tests
       run: |
-        conda run -n csr python -m pytest --cov=csr -v
+        conda run -n csr --no-capture-output python -m pytest --cov=csr -v
 
     - name: Run tests without JIT
       run: |
-        conda run -n csr python -m pytest --cov=csr --cov-append --log-file=test-nojit.log --hypothesis-profile=nojit
+        conda run -n csr --no-capture-output python -m pytest --cov=csr --cov-append --log-file=test-nojit.log --hypothesis-profile=nojit
       env:
         NUMBA_DISABLE_JIT: 1
 

--- a/conftest.py
+++ b/conftest.py
@@ -40,7 +40,7 @@ def kernel(request):
 # set up profiles
 settings.register_profile('default', deadline=1500)
 settings.register_profile('large', settings.get_profile('default'),
-                          max_examples=5000)
+                          max_examples=5000, deadline=None)
 settings.register_profile('fast', max_examples=10)
 settings.register_profile('nojit', settings.get_profile('fast'),
                           deadline=None)

--- a/conftest.py
+++ b/conftest.py
@@ -39,7 +39,8 @@ def kernel(request):
 
 # set up profiles
 settings.register_profile('default', deadline=1500)
-settings.register_profile('large', max_examples=5000)
+settings.register_profile('large', settings.get_profile('default'),
+                          max_examples=5000)
 settings.register_profile('fast', max_examples=10)
 settings.register_profile('nojit', settings.get_profile('fast'),
                           deadline=None)

--- a/csr/_struct.py
+++ b/csr/_struct.py
@@ -17,6 +17,16 @@ class CSRType(types.StructRef):
         "Query whether this CSR type has values."
         return not isinstance(self.field_dict['values'], types.NoneType)
 
+    @property
+    def ptr_type(self):
+        "The type of pointers into the data."
+        return self.field_dict['rowptrs']
+
+    @property
+    def val_type(self):
+        "The value type for the CSR"
+        return self.field_dict['values']
+
 
 @njit
 def get_nrows(self):

--- a/csr/csr.py
+++ b/csr/csr.py
@@ -86,6 +86,8 @@ class CSR(_csr_base):
         cis = np.require(cis, np.intc, 'C')
         if nnz <= INTC.max:
             rps = np.require(rps, np.intc, 'C')
+        else:
+            rps = np.require(rps, np.int64, 'C')
         if vs is not None:
             vs = np.require(vs, requirements='C')
 

--- a/csr/csr.py
+++ b/csr/csr.py
@@ -582,7 +582,7 @@ class CSR(_csr_base):
         repr += '  rowptrs={}\n'.format(self.rowptrs)
         repr += '  colinds={}\n'.format(self.colinds)
         repr += '  values={}\n'.format(self.values)
-        repr += '}'
+        repr += '}>'
         return repr
 
     def __reduce__(self):

--- a/csr/csr.py
+++ b/csr/csr.py
@@ -17,11 +17,11 @@ INTC = np.iinfo(np.intc)
 # ugly hack for a bug on Numba < 0.53
 if config.DISABLE_JIT:
     class _csr_base:
-        def __init__(self, nrows, ncols, nnz, ptrs, inds, vals, cast=True):
+        def __init__(self, nrows, ncols, nnz, ptrs, inds, vals, _cast=True):
             self.nrows = nrows
             self.ncols = ncols
             self.nnz = nnz
-            if cast and np.max(ptrs, initial=0) <= INTC.max:
+            if _cast and np.max(ptrs, initial=0) <= INTC.max:
                 self.rowptrs = np.require(ptrs, np.intc, 'C')
             else:
                 self.rowptrs = np.require(ptrs, requirements='C')

--- a/csr/csr.py
+++ b/csr/csr.py
@@ -51,7 +51,8 @@ class CSR(_csr_base):
     * It is usable from code compiled in Numba's nopython mode.
 
     You generally don't want to create this class yourself with the constructor.  Instead, use one
-    of its class or static methods.
+    of its class or static methods.  If you do use the constructor, be advised that the class may
+    reuse the arrays that you pass, but does not guarantee that they will be used.
 
     Not all methods are available from Numba, and a few have restricted signatures.  The
     documentation for each method notes deviations when in Numba-compiled code.

--- a/csr/csr.py
+++ b/csr/csr.py
@@ -74,19 +74,20 @@ class CSR(_csr_base):
         values(numpy.ndarray or None): the values.
     """
 
-    def __new__(cls, nrows, ncols, nnz, rps, cis, vs, cast=True):
+    def __new__(cls, nrows, ncols, nnz, rps, cis, vs):
         assert nrows >= 0
         assert nrows <= INTC.max
         assert ncols >= 0
         assert ncols <= INTC.max
+        assert nnz >= 0
         nrows = np.intc(nrows)
         ncols = np.intc(ncols)
-        if cast:
-            cis = np.require(cis, np.intc, 'C')
-            if nnz <= INTC.max:
-                rps = np.require(rps, np.intc, 'C')
-            if vs is not None:
-                vs = np.require(vs, requirements='C')
+
+        cis = np.require(cis, np.intc, 'C')
+        if nnz <= INTC.max:
+            rps = np.require(rps, np.intc, 'C')
+        if vs is not None:
+            vs = np.require(vs, requirements='C')
 
         if NUMBA_ENABLED:
             return _csr_base.__new__(cls, nrows, ncols, nnz, rps, cis, vs)
@@ -541,5 +542,5 @@ class CSR(_csr_base):
         return repr
 
     def __reduce__(self):
-        args = (self.nrows, self.ncols, self.nnz, self.rowptrs, self.colinds, self.values, False)
+        args = (self.nrows, self.ncols, self.nnz, self.rowptrs, self.colinds, self.values)
         return (CSR, args)

--- a/csr/csr.py
+++ b/csr/csr.py
@@ -242,6 +242,9 @@ class CSR(_csr_base):
             return vs
 
     def _e_value(self, i):
+        """
+        Get the value of a particular element, returning 1 if values is undefined.
+        """
         vs = self.values
         if vs is not None:
             return vs[i]

--- a/csr/csr.py
+++ b/csr/csr.py
@@ -74,7 +74,7 @@ class CSR(_csr_base):
         values(numpy.ndarray or None): the values.
     """
 
-    def __new__(cls, nrows, ncols, nnz, rps, cis, vs):
+    def __new__(cls, nrows, ncols, nnz, rps, cis, vs, _cast=True):
         assert nrows >= 0
         assert nrows <= INTC.max
         assert ncols >= 0
@@ -83,13 +83,14 @@ class CSR(_csr_base):
         nrows = np.intc(nrows)
         ncols = np.intc(ncols)
 
-        cis = np.require(cis, np.intc, 'C')
-        if nnz <= INTC.max:
-            rps = np.require(rps, np.intc, 'C')
-        else:
-            rps = np.require(rps, np.int64, 'C')
-        if vs is not None:
-            vs = np.require(vs, requirements='C')
+        if _cast:
+            cis = np.require(cis, np.intc, 'C')
+            if nnz <= INTC.max:
+                rps = np.require(rps, np.intc, 'C')
+            else:
+                rps = np.require(rps, np.int64, 'C')
+            if vs is not None:
+                vs = np.require(vs, requirements='C')
 
         if NUMBA_ENABLED:
             return _csr_base.__new__(cls, nrows, ncols, nnz, rps, cis, vs)
@@ -547,5 +548,5 @@ class CSR(_csr_base):
         return repr
 
     def __reduce__(self):
-        args = (self.nrows, self.ncols, self.nnz, self.rowptrs, self.colinds, self.values)
+        args = (self.nrows, self.ncols, self.nnz, self.rowptrs, self.colinds, self.values, False)
         return (CSR, args)

--- a/csr/kernels/mkl/handle.py
+++ b/csr/kernels/mkl/handle.py
@@ -76,14 +76,16 @@ def to_handle_jit(csr):
     else:
         vt = None
 
-    if vt == float64:
-        return _make_handle_impl
-    else:
-        def mkh(csr):
-            vs = csr._required_values().astype(np.float64)
-            csr2 = CSR(csr.nrows, csr.ncols, csr.nnz, csr.rowptrs, csr.colinds, vs)
-            return _make_handle(csr2)
-        return mkh
+    def mkh(csr):
+        vs = csr._required_values().astype(np.float64)
+        csr2 = CSR(csr.nrows, csr.ncols, csr.nnz, csr.rowptrs, csr.colinds, vs)
+
+        if csr.nnz == 0:
+            return mkl_h(0, csr.nrows, csr.ncols, csr2)
+
+        return _make_handle(csr2)
+
+    return mkh
 
 
 @njit

--- a/csr/kernels/mkl/handle.py
+++ b/csr/kernels/mkl/handle.py
@@ -1,9 +1,11 @@
 import sys
 from typing import Optional
 import dataclasses
+from numba.core.types.functions import _ResolutionFailures
 import numpy as np
 from numba import njit, config
-from numba.core.types import StructRef
+from numba.extending import overload
+from numba.core.types import StructRef, intc, float64
 from numba.experimental import structref
 
 from csr import CSR
@@ -30,30 +32,58 @@ if config.DISABLE_JIT:
         H: int
         nrows: int
         ncols: int
-        values: Optional[np.ndarray]
+        csr_ref: Optional[np.ndarray]
 else:
     class mkl_h(structref.StructRefProxy):
         """
         Type for MKL handles.  Opaque, do not use directly.
         """
 
-    structref.define_proxy(mkl_h, mkl_h_type, ['H', 'nrows', 'ncols', 'values'])
+    structref.define_proxy(mkl_h, mkl_h_type, ['H', 'nrows', 'ncols', 'csr_ref'])
 
 
-@njit
-def to_handle(csr: CSR) -> mkl_h:
-    if csr.nnz == 0:
-        # empty matrices don't really work
-        return mkl_h(0, csr.nrows, csr.ncols, np.zeros(0))
-
+def _make_handle_impl(csr):
+    "Make a handle from a known-constructable CSR"
     _sp = ffi.from_buffer(csr.rowptrs)
     _cols = ffi.from_buffer(csr.colinds)
-    vs = csr._required_values()
+    vs = csr.values
     assert vs.size == csr.nnz
     _vals = ffi.from_buffer(vs)
     h = lk_mkl_spcreate(csr.nrows, csr.ncols, _sp, _cols, _vals)
     lk_mkl_spopt(h)
-    return mkl_h(h, csr.nrows, csr.ncols, vs)
+    return mkl_h(h, csr.nrows, csr.ncols, csr)
+
+
+_make_handle = njit(_make_handle_impl)
+
+
+def to_handle(csr: CSR) -> mkl_h:
+    if csr.nnz == 0:
+        # empty matrices don't really work
+        return mkl_h(0, csr.nrows, csr.ncols, None)
+
+    norm = csr._normalize(np.float64, np.intc)
+    return _make_handle(norm)
+
+
+@overload(to_handle)
+def to_handle_jit(csr):
+    if csr.ptr_type.dtype != intc:
+        raise TypeError('MKL requires intc row pointers')
+
+    if csr.has_values:
+        vt = csr.val_type.dtype
+    else:
+        vt = None
+
+    if vt == float64:
+        return _make_handle_impl
+    else:
+        def mkh(csr):
+            vs = csr._required_values().astype(np.float64)
+            csr2 = CSR(csr.nrows, csr.ncols, csr.nnz, csr.rowptrs, csr.colinds, vs)
+            return _make_handle(csr2)
+        return mkh
 
 
 @njit

--- a/csr/kernels/mkl/mkl_ops.c
+++ b/csr/kernels/mkl/mkl_ops.c
@@ -55,7 +55,7 @@ lk_mkl_spcreate(int nrows, int ncols, int *rowptrs, int *colinds, double *values
     check_return("mkl_sparse_d_create_csr", rv);
 
 #ifdef LK_TRACE
-    fprintf(stderr, "allocated 0x%8lx (%dx%d) %d\n", matrix, nrows, ncols, rowptrs[nrows]);
+    fprintf(stderr, "allocated 0x%8lx (%dx%d, %d nnz)\n", matrix, nrows, ncols, rowptrs[nrows]);
 #endif
     return H(matrix);
 }

--- a/tests/test_mkl.py
+++ b/tests/test_mkl.py
@@ -1,0 +1,42 @@
+"""
+Various MKL-specific tests.
+"""
+
+import pytest
+from numba import njit
+import numpy as np
+
+from csr.test_utils import csrs
+
+from hypothesis import given
+
+try:
+    from csr.kernels import mkl
+except ImportError:
+    pytestmark = pytest.skip("MKL is not available")
+
+
+@njit
+def make_handle(csr):
+    return mkl.to_handle(csr)
+
+
+@njit
+def unhandle(h):
+    return mkl.from_handle(h)
+
+
+@given(csrs())
+def test_csr_handle(csr):
+    h = make_handle(csr)
+    csr2 = unhandle(h)
+
+    assert csr2.nrows == csr.nrows
+    assert csr2.ncols == csr.ncols
+    assert csr2.nnz == csr.nnz
+    assert np.all(csr2.rowptrs == csr.rowptrs)
+    assert np.all(csr2.colinds == csr.colinds)
+    if csr.values is not None:
+        assert np.all(csr2.values == csr.values)
+    else:
+        assert np.all(csr2.values == 1.0)

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -25,12 +25,12 @@ def test_csr_pickle(csr):
         assert csr2.values is None
 
 
-@pytest.skip(reason='rethinking 64-bit support')
 @csr_slow()
 @given(csrs())
 def test_csr64_pickle(csr):
     csr = CSR(csr.nrows, csr.ncols, csr.nnz,
-              csr.rowptrs.astype(np.int64), csr.colinds, csr.values)
+              csr.rowptrs.astype(np.int64), csr.colinds, csr.values,
+              _cast=False)
 
     data = pickle.dumps(csr)
     csr2 = pickle.loads(data)

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -4,6 +4,7 @@ import pickle
 from csr import CSR
 from csr.test_utils import csrs, csr_slow
 
+import pytest
 from hypothesis import given
 
 
@@ -24,11 +25,12 @@ def test_csr_pickle(csr):
         assert csr2.values is None
 
 
+@pytest.skip(reason='rethinking 64-bit support')
 @csr_slow()
 @given(csrs())
 def test_csr64_pickle(csr):
     csr = CSR(csr.nrows, csr.ncols, csr.nnz,
-              csr.rowptrs.astype(np.int64), csr.colinds, csr.values, False)
+              csr.rowptrs.astype(np.int64), csr.colinds, csr.values)
 
     data = pickle.dumps(csr)
     csr2 = pickle.loads(data)


### PR DESCRIPTION
This PR checks and enforces limits on the MKL interfaces, and adds data transformations to ensure that it works when possible.

The MKL kernel cannot handle matrices with more than `INT_MAX` nonzero elements. We now have much better checking, along with utility methods and logic to help with this enforcement and appropriate data transformations.