### PR TITLE
Support very large matrix multiplication with MKL

### DIFF
--- a/csr/csr.py
+++ b/csr/csr.py
@@ -521,6 +521,9 @@ class CSR(_csr_base):
             assert self.ncols == other.nrows
 
         K = get_kernel()
+        if self.nnz > K.max_nnz:
+            raise ValueError(f'matrix size {self.nnz} too large for kernel {K}')
+
         with releasing(K.to_handle(self), K) as a_h:
             with releasing(K.to_handle(other), K) as b_h:
                 if transpose:
@@ -544,6 +547,9 @@ class CSR(_csr_base):
         """
         assert v.shape == (self.ncols,)
         K = get_kernel()
+        if self.nnz > K.max_nnz:
+            raise ValueError(f'matrix size {self.nnz} too large for kernel {K}')
+
         with releasing(K.to_handle(self), K) as h:
             return K.mult_vec(h, v)
 

--- a/csr/csr.py
+++ b/csr/csr.py
@@ -291,7 +291,6 @@ class CSR(_csr_base):
 
         return CSR(self.nrows, self.ncols, self.nnz, rps, self.colinds, vs, _cast=False)
 
-
     @property
     def R(self):
         warnings.warn('.R deprecated, use CSR directly', DeprecationWarning)

--- a/csr/csr.py
+++ b/csr/csr.py
@@ -590,7 +590,6 @@ class CSR(_csr_base):
             _log.debug('splitting %s at %d (rp@s: %d)', rest, split, rest.rowptrs[split])
             shards.append(rest.subset_rows(0, split))
             rest = rest.subset_rows(split, rest.nrows)
-            return shards
 
         shards.append(rest)
         return shards

--- a/csr/kernels/mkl/__init__.py
+++ b/csr/kernels/mkl/__init__.py
@@ -1,2 +1,5 @@
+import numpy as np
 from .handle import to_handle, from_handle, release_handle, order_columns
 from .multiply import mult_ab, mult_abt, mult_vec
+
+max_nnz = np.iinfo('i4').max

--- a/csr/kernels/numba/__init__.py
+++ b/csr/kernels/numba/__init__.py
@@ -10,6 +10,8 @@ from csr import CSR
 from .multiply import mult_ab, mult_abt  # noqa: F401
 from ...structure import sort_rows
 
+max_nnz = np.iinfo('i8').max
+
 
 @njit
 def to_handle(csr):

--- a/csr/kernels/scipy.py
+++ b/csr/kernels/scipy.py
@@ -8,6 +8,8 @@ import numpy as np
 from scipy.sparse import csr_matrix
 from csr import CSR
 
+max_nnz = np.iinfo('i8').max
+
 
 def to_handle(csr: CSR):
     values = csr.values

--- a/docs/kernels.rst
+++ b/docs/kernels.rst
@@ -89,3 +89,16 @@ Multiplication
 .. autofunction:: mult_vec
 .. autofunction:: mult_ab
 .. autofunction:: mult_abt
+
+Additional Requirements
+~~~~~~~~~~~~~~~~~~~~~~~
+
+There are additional requirements for kernel implementations:
+
+.. py:attribute:: max_nnz
+    :type: int
+
+    This attribute stores the maximum number of non-zero entries supported by this kernel. It is not
+    exposed on the kernel module, but is exposed on dynamically-obtained kernels, and must be
+    provided by any kernel implementation.  It is used by :py:class:`csr._CSR` to automatically
+    handle matrices that are too large for a particular kernel when possible.

--- a/tests/test_mkl.py
+++ b/tests/test_mkl.py
@@ -8,12 +8,10 @@ from numba import njit, prange
 import numpy as np
 
 from csr import CSR
-from csr.test_utils import csrs, sparse_matrices, mm_pairs
+from csr.test_utils import csrs
 
-from pytest import approx, fixture, skip
-from hypothesis import given, settings
-import hypothesis.strategies as st
-import hypothesis.extra.numpy as nph
+from pytest import skip, mark
+from hypothesis import given
 
 import test_multiply as tmm
 import test_mult_vec as tmv
@@ -80,12 +78,14 @@ def test_mult_vec_lim():
         tmv.test_mult_vec(mkl)
 
 
+@mark.skip('not yet implemented')
 def test_multiply_lim():
     "Test matrix-matrix multiply with limited kernel capacity"
     with mkl_lim():
         tmm.test_multiply(mkl)
 
 
+@mark.skip('not yet implemented')
 def test_multiply_transpose_lim():
     "Select matrix-matrix transpose multiply with limited kernel capacity"
     with mkl_lim():

--- a/tests/test_mkl.py
+++ b/tests/test_mkl.py
@@ -6,6 +6,7 @@ import pytest
 from numba import njit
 import numpy as np
 
+from csr import CSR
 from csr.test_utils import csrs
 
 from hypothesis import given
@@ -40,3 +41,39 @@ def test_csr_handle(csr):
         assert np.all(csr2.values == csr.values)
     else:
         assert np.all(csr2.values == 1.0)
+
+
+def test_large_mult_vec():
+    # 10M * 500 = 2.5B >= INT_MAX
+    nrows = 10000000
+    ncols = 500
+    dense = 250
+    nnz = nrows * dense
+
+    rowptrs = np.arange(0, nnz + 1, dense, dtype=np.int64)
+
+    assert len(rowptrs) == nrows + 1
+    assert rowptrs[-1] == nnz
+
+    try:
+        print('allocating indexes')
+        colinds = np.empty(nnz, dtype=np.intc)
+        print('allocating values')
+        values = np.random.randn(nnz)
+    except MemoryError:
+        pytest.skip('insufficient memory')
+
+    print('randomizing colinds')
+    for i in range(nrows):
+        s = i * dense
+        e = s + dense
+        colinds[s:e] = np.random.choice(ncols, dense, replace=False)
+
+    csr = CSR(nrows, ncols, nnz, rowptrs, colinds, values)
+
+    v = np.random.nrand(ncols)
+
+    res = csr.mult_vec(v)
+
+    assert res.shape == (nrows,)
+    assert np.all(~np.isnan(res))

--- a/tests/test_mkl.py
+++ b/tests/test_mkl.py
@@ -28,12 +28,14 @@ _log = logging.getLogger(__name__)
 
 
 @contextmanager
-def mkl_lim(n=5000):
+def mkl_lim(lim=1000):
     "Limit MKL to a capacity of X"
-    MKL_LIM = 1000
+    save = mkl.max_nnz
     try:
-        yield MKL_LIM
+        mkl.max_nnz = lim
+        yield lim
     finally:
+        mkl.max_nnz = save
         pass
 
 

--- a/tests/test_mkl.py
+++ b/tests/test_mkl.py
@@ -78,14 +78,12 @@ def test_mult_vec_lim():
         tmv.test_mult_vec(mkl)
 
 
-@mark.skip('not yet implemented')
 def test_multiply_lim():
     "Test matrix-matrix multiply with limited kernel capacity"
     with mkl_lim():
         tmm.test_multiply(mkl)
 
 
-@mark.skip('not yet implemented')
 def test_multiply_transpose_lim():
     "Select matrix-matrix transpose multiply with limited kernel capacity"
     with mkl_lim():

--- a/tests/test_mkl.py
+++ b/tests/test_mkl.py
@@ -76,7 +76,7 @@ def test_large_mult_vec():
 
     csr = CSR(nrows, ncols, nnz, rowptrs, colinds, values)
 
-    v = np.random.nrand(ncols)
+    v = np.random.randn(ncols)
 
     res = csr.mult_vec(v)
 

--- a/tests/test_multiply.py
+++ b/tests/test_multiply.py
@@ -4,7 +4,7 @@ from csr import CSR
 from csr.test_utils import mm_pairs
 
 from pytest import approx
-from hypothesis import given, settings
+from hypothesis import given, settings, assume
 
 _log = logging.getLogger(__name__)
 
@@ -15,6 +15,7 @@ def test_multiply(kernel, pair):
     A, B = pair
     csra = CSR.from_scipy(A)
     csrb = CSR.from_scipy(B)
+    assume(csrb.nnz <= kernel.max_nnz)
 
     prod = csra.multiply(csrb)
     assert isinstance(prod, CSR)
@@ -47,6 +48,7 @@ def test_multiply_transpose(kernel, pair):
     A, B = pair
     csra = CSR.from_scipy(A)
     csrb = CSR.from_scipy(B.T)
+    assume(csrb.nnz <= kernel.max_nnz)
 
     prod = csra.multiply(csrb, transpose=True)
     assert isinstance(prod, CSR)


### PR DESCRIPTION
This PR enables support for certain multiplication operations on very large matrices (`nnz > INT_MAX`) with MKL.

Supported:

- [x] *A v* where `A.nnz` large
- [x] *A B* where `A.nnz` large

Unsupported operations raise a proper error instead of silently failing.