### PR TITLE
Test with Python 3.10 and Numba 0.55

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ defaults:
     shell: bash -l {0}
 
 jobs:
-  test:
-    name: Test with Python ${{matrix.python}} on ${{matrix.platform}}
+  test-conda:
+    name: Test with Conda Python ${{matrix.python}} on ${{matrix.platform}}
     runs-on: ${{matrix.platform}}-latest
     strategy:
       fail-fast: false
@@ -77,10 +77,59 @@ jobs:
     - name: Upload coverage
       uses: codecov/codecov-action@v1
 
+  test-vanilla:
+    name: Test w/ Vanilla Python ${{matrix.python}} on ${{matrix.platform}}
+    runs-on: ${{matrix.platform}}-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+        - "3.7"
+        - "3.8"
+        - "3.9"
+        - "3.10"
+        platform:
+        - windows
+        - ubuntu
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{matrix.python}}
+          architecture: x64
+
+      - name: Set up Python build deps
+        env:
+          PIP_PREFER_BINARY: 'true'
+        run: |
+          python -m pip install -U flit wheel
+
+      - name: Install CSR and its deps
+        env:
+          PIP_PREFER_BINARY: 'true'
+        run: |
+          flit install --pth-file --deps dev
+
+      - name: Run tests
+        run: |
+          python -m pytest --cov=csr --cov-report=xml --log-file=test.log
+
+      - name: Aggreagate Coverage Data
+        run: coverage xml
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v1
+
   sdist:
     name: Build Source Packages
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [test-conda, test-vanilla]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,7 +114,7 @@ jobs:
         env:
           PIP_PREFER_BINARY: 'true'
         run: |
-          flit install --pth-file --deps dev
+          flit install --pth-file --deps develop
 
       - name: Run tests
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = ["License :: OSI Approved :: MIT License"]
 description-file = "README.md"
 requires-python = ">= 3.7"
 requires = [
-    "numba >=0.51,<0.55",
+    "numba >=0.51,<0.56",
     "numpy >=1.17",
     "scipy ==1.*"
 ]


### PR DESCRIPTION
Three dep/environment changes:

- Add vanilla Python to test matrix
- Add Python 3.10 to test matrix
- Bump max Numba version to allow 0.55 (and thus Python 3.10)