### PR TITLE
Update test pipelines

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,8 +75,14 @@ jobs:
     - name: Aggregate coverage data
       run: coverage xml
 
-    - name: Upload coverage
-      uses: codecov/codecov-action@v1
+    - name: Upload logs
+      uses: actions/upload-artifact@v2
+      with:
+        name: log-conda-${{matrix.platform}}-py${{matrix.python}}
+        path: |
+          test*.log
+          coverage.xml
+          emissions.csv
 
   test-vanilla:
     name: Test w/ Vanilla Python ${{matrix.python}} on ${{matrix.platform}}
@@ -124,11 +130,17 @@ jobs:
       - name: Aggreagate Coverage Data
         run: coverage xml
 
-      - name: Upload coverage
-        uses: codecov/codecov-action@v1
+      - name: Upload logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: log-vanilla-${{matrix.platform}}-py${{matrix.python}}
+          path: |
+            test*.log
+            coverage.xml
+            emissions.csv
 
   sdist:
-    name: Build Source Packages
+    name: Process Build & Test Results
     runs-on: ubuntu-latest
     needs: [test-conda, test-vanilla]
 
@@ -148,14 +160,33 @@ jobs:
     - name: Install Python deps
       run: pip install -U flit
 
+    - name: Download test results
+      uses: actions/download-artifact@v2
+      with:
+        path: test-logs
+
+    - name: List log files
+      run: ls -lR test-logs
+
+    - name: Upload test coverage
+      uses: codecov/codecov-action@v2
+      with:
+        directory: test-logs/
+
     - name: Build distribution
       run: flit build
 
-    - name: Save archive
-      uses: actions/upload-artifact@v1
+    - name: Save distribution archive
+      uses: actions/upload-artifact@v2
       with:
         name: pypi-pkgs
         path: dist
+
+    - name: Upload all test data
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-outputs
+        path: test-logs
 
     - name: List dist dir
       run: ls -R dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,10 @@ jobs:
         - windows
         - ubuntu
         python:
-        - 3.7
-        - 3.8
-        - 3.9
+        - "3.7"
+        - "3.8"
+        - "3.9"
+        - "3.10"
 
     steps:
     - uses: actions/checkout@v2

--- a/tests/test_multiply.py
+++ b/tests/test_multiply.py
@@ -1,7 +1,7 @@
 import logging
 
 from csr import CSR
-from csr.test_utils import mm_pairs
+from csr.test_utils import mm_pairs, csr_slow
 
 from pytest import approx
 from hypothesis import given, settings, assume
@@ -9,7 +9,7 @@ from hypothesis import given, settings, assume
 _log = logging.getLogger(__name__)
 
 
-@settings(deadline=None)
+@csr_slow()
 @given(mm_pairs())
 def test_multiply(kernel, pair):
     A, B = pair
@@ -42,7 +42,7 @@ def test_multiply(kernel, pair):
         assert r_ours == approx(r_scipy)
 
 
-@settings(deadline=None)
+@csr_slow()
 @given(mm_pairs())
 def test_multiply_transpose(kernel, pair):
     A, B = pair


### PR DESCRIPTION
This updates the test pipelines for two changes:

- Add Python 3.10 to the Conda test matrix
- Defer coverage upload until the whole test matrix has run