### PR TITLE
Remove the .R accessor

### DIFF
--- a/csr/csr.py
+++ b/csr/csr.py
@@ -298,11 +298,6 @@ class CSR(_csr_base):
 
         return CSR(self.nrows, self.ncols, self.nnz, rps, self.colinds, vs, _cast=False)
 
-    @property
-    def R(self):
-        warnings.warn('.R deprecated, use CSR directly', DeprecationWarning)
-        return self
-
     def copy(self, include_values=True, *, copy_structure=True):
         """
         Create a copy of this CSR.

--- a/tests/test_handles.py
+++ b/tests/test_handles.py
@@ -10,7 +10,7 @@ from hypothesis import given
 @csr_slow(divider=1)
 @given(csrs())
 def test_make_handle(kernel, csr):
-    h = kernel.to_handle(csr.R)
+    h = kernel.to_handle(csr)
     try:
         assert h is not None
         c2 = kernel.from_handle(h)

--- a/tests/test_kernel_numba.py
+++ b/tests/test_kernel_numba.py
@@ -17,7 +17,7 @@ def test_symb(pair):
 
     cp = np.zeros_like(A.rowptrs)
 
-    cci = _sym_mm(A.R, B.R, cp)
+    cci = _sym_mm(A, B, cp)
 
     # Is everything in range?
     assert all(cci >= 0)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -78,7 +78,7 @@ def test_sort_rows(csr):
 def test_kernel_sort_rows(kernel, csr):
     tv = np.ones(csr.ncols)
     x1 = csr.mult_vec(tv)
-    h = kernel.to_handle(csr.R)
+    h = kernel.to_handle(csr)
     kernel.order_columns(h)
     c2 = kernel.from_handle(h)
     kernel.release_handle(h)


### PR DESCRIPTION
This removes the deprecated `.R` accessor on CSR.