### PR TITLE
Correct test failures with updated dependencies

### DIFF
--- a/csr/_struct.py
+++ b/csr/_struct.py
@@ -56,3 +56,22 @@ def get_colinds(self):
 @njit
 def get_values(self):
     return self.values
+
+
+def _filter_zeros(csr):
+    "Filter out the zero values in a CSR, in-place."
+    nnz = 0
+    for i in range(csr.nrows):
+        sp, ep = csr.row_extent(i)
+        csr.rowptrs[i] = nnz
+        for jp in range(sp, ep):
+            if csr.values[jp] != 0:
+                csr.colinds[nnz] = csr.colinds[jp]
+                csr.values[nnz] = csr.values[jp]
+                nnz += 1
+
+    csr.rowptrs[csr.nrows] = nnz
+    csr.nnz = nnz
+
+
+filter_zeros = njit(nogil=True)(_filter_zeros)

--- a/csr/csr.py
+++ b/csr/csr.py
@@ -539,6 +539,7 @@ class CSR(_csr_base):
                 with releasing(c_h, K):
                     crepr = K.from_handle(c_h)
 
+            crepr._filter_zeros()
             return crepr
 
         if self.nnz <= K.max_nnz:
@@ -574,6 +575,13 @@ class CSR(_csr_base):
                 with releasing(K.to_handle(s), K) as h:
                     svs.append(K.mult_vec(h, v))
             return np.concatenate(svs)
+
+    def _filter_zeros(self):
+        """
+        Filter out the stored zero values in-place.
+        """
+        if self.values is not None:
+            _struct.filter_zeros(self)
 
     def _shard_rows(self, tgt_nnz):
         """

--- a/csr/transform.py
+++ b/csr/transform.py
@@ -4,6 +4,7 @@ Data transformation implementations.
 
 import logging
 import numpy as np
+import math
 from numba import njit
 
 _log = logging.getLogger(__name__)
@@ -28,14 +29,28 @@ def center_rows(csr):
 @njit(nogil=True)
 def unit_rows(csr):
     "Normalize the rows of a CSR to unit vectors."
+    info = np.finfo(csr.values.dtype)
     norms = np.zeros(csr.nrows, dtype=csr.values.dtype)
     for i in range(csr.nrows):
         sp, ep = csr.row_extent(i)
         if sp == ep:
             continue  # empty row
         vs = csr.row_vs(i)
-        m = np.linalg.norm(vs)
-        norms[i] = m
-        csr.values[sp:ep] /= m
+
+        # this hack courtesy of @jekstrand
+        # find the maximum absolute value
+        vmax = np.max(np.abs(vs))
+
+        # get its exponent, and pre-normalize to bring the values up if they're all tiny
+        vm, ve = math.frexp(vmax)
+        pnexp = min(-ve, info.maxexp - 1)
+        pnexp = max(pnexp, info.minexp)
+        prenorm = math.ldexp(1.0, pnexp)
+        csr.values[sp:ep] *= prenorm
+
+        # now we normalize the non-subnormal values
+        inorm = np.linalg.norm(csr.values[sp:ep])
+        norms[i] = inorm / prenorm
+        csr.values[sp:ep] /= inorm
 
     return norms

--- a/tests/test_mult_vec.py
+++ b/tests/test_mult_vec.py
@@ -21,7 +21,7 @@ def test_mult_vec(kernel, data, csra):
 
     v2 = md @ v
 
-    assert prod == approx(v2, nan_ok=True, rel=1.0e-5)
+    assert prod == approx(v2, nan_ok=True, rel=1.0e-5, abs=1.0e-10)
 
 
 @settings(deadline=None)


### PR DESCRIPTION
This corrects some erroneous behavior found with dependency upgrades:

- make unit-normalization properly handle very low-magnitude vectors
- fix multiplication tests to not fail under new hypothesis updates (presumably)