### PR TITLE
Add a minimum-dependencies test to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,6 +113,40 @@ jobs:
             coverage.xml
             emissions.csv
 
+  test-mindeps:
+    name: Test w/ Oldest Deps
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python and environment
+        uses: lenskit/lkbuild/actions/setup-vanilla-env@main
+        with:
+          python-version: "3.7"
+          include-dev-dependencies: false
+          extras: test
+          constraints-file: min-constraints.txt
+
+      - name: Run tests
+        run: |
+          python -m pytest --cov=csr --cov-report=xml --log-file=test.log
+
+      - name: Aggreagate Coverage Data
+        run: coverage xml
+
+      - name: Upload logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: log-vanilla-${{matrix.platform}}-py${{matrix.python}}
+          path: |
+            test*.log
+            coverage.xml
+            emissions.csv
+
   sdist:
     name: Process Build & Test Results
     runs-on: ubuntu-latest

--- a/min-constraints.txt
+++ b/min-constraints.txt
@@ -2,7 +2,7 @@
 # core deps
 numpy==1.17.0
 numba==0.51.0
-scipy==1.0.0
+scipy==1.1.0
 
 # test deps
 pytest==6.0

--- a/min-constraints.txt
+++ b/min-constraints.txt
@@ -1,0 +1,9 @@
+# constraints to install older supported versions of deps
+# core deps
+numpy==1.17.0
+numba==0.51.0
+scipy==1.0.0
+
+# test deps
+pytest==6.0
+hypothesis==6.0

--- a/min-constraints.txt
+++ b/min-constraints.txt
@@ -6,4 +6,4 @@ scipy==1.1.0
 
 # test deps
 pytest==6.0
-hypothesis==6.0
+hypothesis==6.30.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ test = [
     "pytest-doctestplus >=0.9",
     "pytest-benchmark >=3",
     "pytest-cov >=2.12",
-    "hypothesis >=6",
+    "hypothesis ~=6.30",
     "psutil >=5"
 ]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">= 3.7"
 requires = [
     "numba >=0.51,<0.56",
     "numpy >=1.17",
-    "scipy ==1.*"
+    "scipy >=1.1,<2"
 ]
 
 [tool.flit.metadata.requires-extra]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dev = [
     "flake8",
     "rstcheck",
     "invoke",
-    "lenskit-build-helpers",
+    "lenskit-build-helpers >=0.1",
     "sphinx-autobuild >=2021",
 ]
 doc = [


### PR DESCRIPTION
This adds tests to the CI suite that test with the oldest supported version of dependencies, to make sure those stay current.