### PR TITLE
Enable Numba 0.56 in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = ["License :: OSI Approved :: MIT License"]
 description-file = "README.md"
 requires-python = ">= 3.7"
 requires = [
-    "numba >=0.51,<0.56",
+    "numba >=0.51,<0.57",
     "numpy >=1.17",
     "scipy >=1.1,<2"
 ]


### PR DESCRIPTION
This enables Numba 0.56 in tests for the 0.4 series (closes #35)