### PR TITLE
Update metadata to PEP 621

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run Tests
+name: Test and Publish
 on:
   push:
     branches:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,22 +1,32 @@
 [build-system]
-requires = ["flit_core >=2,<4"]
+requires = ["flit_core >=3.2,<4"]
 build-backend = "flit_core.buildapi"
 
-[tool.flit.metadata]
-module = "csr"
-author = "Michael Ekstrand <michaelekstrand@boisestate.edu>"
-author-email = "michaelekstrand@boisestate.edu"
-home-page = "https://csr.lenskit.org"
-classifiers = ["License :: OSI Approved :: MIT License"]
-description-file = "README.md"
+[project]
+name = "csr"
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Intended Audience :: Science/Research",
+]
+readme = "README.md"
+license = { file = "LICENSE" }
+dynamic = ['version', 'description']
 requires-python = ">= 3.7"
-requires = [
+dependencies = [
     "numba >=0.51,<0.57",
     "numpy >=1.17",
     "scipy >=1.2,<2"
 ]
 
-[tool.flit.metadata.requires-extra]
+[[project.authors]]
+name = "Michael Ekstrand"
+email = "michaelekstrand@boisestate.edu"
+
+[project.urls]
+home-page = "https://csr.lenskit.org"
+source = "https://github.com/lenskit/csr"
+
+[project.optional-dependencies]
 test = [
     "pytest >=6",
     "pytest-doctestplus >=0.9",
@@ -26,7 +36,7 @@ test = [
     "psutil >=5"
 ]
 dev = [
-    "flit",
+    "flit >=3.2,<4",
     "keyring",
     "flake8",
     "rstcheck",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,10 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Intended Audience :: Science/Research",
 ]
+description = "Compressed Sparse Row matrices for Python, with Numba API."
 readme = "README.md"
 license = { file = "LICENSE" }
-dynamic = ['version', 'description']
+dynamic = ['version']
 requires-python = ">= 3.7"
 dependencies = [
     "numba >=0.51,<0.57",


### PR DESCRIPTION
This updates the CSR project metadata (`pyproject.toml`) to follow PEP 621, and cleans up the name of a workflow.