### PR TITLE
Support arrays of indices in row()

### DIFF
--- a/csr/_rows.py
+++ b/csr/_rows.py
@@ -3,6 +3,7 @@ Implementations of CSR row access functions.
 """
 
 import numpy as np
+from numba import njit
 
 
 def extent(csr, row):
@@ -12,18 +13,21 @@ def extent(csr, row):
     return sp, ep
 
 
+@njit
 def _fill_vals(csr, row, array):
     sp, ep = csr.row_extent(row)
     cols = csr.colinds[sp:ep]
     array[cols] = csr.values[sp:ep]
 
 
+@njit
 def _fill_ones(csr, row, array):
     sp, ep = csr.row_extent(row)
     cols = csr.colinds[sp:ep]
     array[cols] = 1
 
 
+@njit
 def _row_array(csr, row, fill, dtype):
     v = np.zeros(csr.ncols, dtype=dtype)
     if csr.nnz == 0:
@@ -33,6 +37,7 @@ def _row_array(csr, row, fill, dtype):
     return v
 
 
+@njit
 def _mr_matrix(csr, rows, fill, dtype):
     v = np.zeros(rows.shape + (csr.ncols,), dtype=dtype)
     if csr.nnz == 0:
@@ -49,7 +54,7 @@ def _row_array_vals(csr, row):
 
 
 def _row_array_ones(csr, row):
-    return _row_array(csr, row, _fill_ones, None)
+    return _row_array(csr, row, _fill_ones, np.bool_)
 
 
 def _mr_matrix_vals(csr, row):
@@ -57,7 +62,7 @@ def _mr_matrix_vals(csr, row):
 
 
 def _mr_matrix_ones(csr, row):
-    return _mr_matrix(csr, row, _fill_ones, None)
+    return _mr_matrix(csr, row, _fill_ones, np.bool_)
 
 
 def row_array(csr, row):

--- a/csr/_wiring.py
+++ b/csr/_wiring.py
@@ -3,6 +3,7 @@ Wire together the Numba and Python types.
 """
 
 import numpy as np
+from numba import types
 from numba.extending import overload_method
 from numba.experimental import structref
 
@@ -23,10 +24,16 @@ def _csr_row_extent(csr, row):
 
 @overload_method(CSRType, 'row')
 def _csr_row(csr, row):
-    if csr.has_values:
-        return _rows._row_array_vals
-    else:
-        return _rows._row_array_ones
+    if isinstance(row, types.Integer):
+        if csr.has_values:
+            return _rows._row_array_vals
+        else:
+            return _rows._row_array_ones
+    elif isinstance(row, types.ArrayCompatible):
+        if csr.has_values:
+            return _rows._mr_matrix_vals
+        else:
+            return _rows._mr_matrix_ones
 
 
 @overload_method(CSRType, 'row_cs')

--- a/csr/_wiring.py
+++ b/csr/_wiring.py
@@ -24,9 +24,9 @@ def _csr_row_extent(csr, row):
 @overload_method(CSRType, 'row')
 def _csr_row(csr, row):
     if csr.has_values:
-        return _rows._array_vals
+        return _rows._row_array_vals
     else:
-        return _rows._array_ones
+        return _rows._row_array_ones
 
 
 @overload_method(CSRType, 'row_cs')

--- a/csr/csr.py
+++ b/csr/csr.py
@@ -372,9 +372,7 @@ class CSR(_csr_base):
 
     def row(self, row):
         """
-        Return a row of this matrix as a dense ndarray.
-
-        .. note:: This method only supports single indices in Numba mode.
+        Return one or more rows of this matrix as a dense ndarray.
 
         Args:
             row(int or numpy.ndarray): the row index or indices.

--- a/csr/csr.py
+++ b/csr/csr.py
@@ -374,8 +374,10 @@ class CSR(_csr_base):
         """
         Return a row of this matrix as a dense ndarray.
 
+        .. note:: This method only supports single indices in Numba mode.
+
         Args:
-            row(int): the row index.
+            row(int or numpy.ndarray): the row index or indices.
 
         Returns:
             numpy.ndarray:
@@ -383,7 +385,8 @@ class CSR(_csr_base):
                 stores matrix structure, the returned vector has 1s where the CSR
                 records an entry.
         """
-        return _rows.array(self, row)
+        row = np.asarray(row, dtype='i4')
+        return _rows.row_array(self, row)
 
     def row_extent(self, row):
         """

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,3 +1,4 @@
+import logging
 import numpy as np
 import scipy.sparse as sps
 
@@ -8,6 +9,8 @@ from pytest import raises
 from hypothesis import given, assume
 import hypothesis.strategies as st
 import hypothesis.extra.numpy as nph
+
+_log = logging.getLogger(__name__)
 
 
 def test_csr_rowinds():
@@ -75,6 +78,17 @@ def test_csr_row(csr):
         assert row.size == other.size
 
         assert all(row == other)
+
+
+@csr_slow()
+@given(st.data(), csrs(st.integers(1, 100), st.integers(1, 100)))
+def test_csr_rows(data, csr):
+    smat = csr.to_scipy()
+
+    rows = data.draw(st.lists(st.integers(0, csr.nrows - 1), max_size=csr.nrows, unique=True))
+    row_arrs = csr.row(rows)
+    other = smat[rows, :].toarray()
+    assert np.all(row_arrs == other)
 
 
 def test_csr_sparse_row():

--- a/tests/test_numba.py
+++ b/tests/test_numba.py
@@ -68,12 +68,27 @@ def _row(csr, row):
 
 @given(csrs())
 def test_csr_row(csr):
-
     for i in range(csr.nrows):
         cr = csr.row(i)
         nr = _row(csr, i)
         assert nr.shape == cr.shape
         assert all(nr == cr)
+
+
+@njit
+def _rows(csr, rows):
+    return csr.row(rows)
+
+
+@given(st.data(), csrs())
+def test_csr_rows(data, csr):
+    rows = data.draw(st.lists(st.integers(0, csr.nrows - 1), unique=True))
+    rows = np.asarray(rows, dtype='i4')
+    cmat = csr.row(rows)
+    nmat = _rows(csr, rows)
+
+    assert nmat.shape == cmat.shape
+    assert np.all(nmat == cmat)
 
 
 @njit


### PR DESCRIPTION
This extends `CSR.row()` to support arrays of indices, in which case it returns an `ndarray` matrix with the requested rows.