### PR TITLE
Add row_mask method to CSR

### DIFF
--- a/csr/_rows.py
+++ b/csr/_rows.py
@@ -54,6 +54,10 @@ def _row_array_vals(csr, row):
 
 
 def _row_array_ones(csr, row):
+    return _row_array(csr, row, _fill_ones, np.float32)
+
+
+def _row_array_mask(csr, row):
     return _row_array(csr, row, _fill_ones, np.bool_)
 
 
@@ -62,6 +66,10 @@ def _mr_matrix_vals(csr, row):
 
 
 def _mr_matrix_ones(csr, row):
+    return _mr_matrix(csr, row, _fill_ones, np.float32)
+
+
+def _mr_matrix_mask(csr, row):
     return _mr_matrix(csr, row, _fill_ones, np.bool_)
 
 
@@ -77,6 +85,14 @@ def row_array(csr, row):
             return _mr_matrix_vals(csr, row)
         else:
             return _mr_matrix_ones(csr, row)
+
+
+def row_mask(csr, row):
+    "Get a row of the CSR as an array"
+    if row.shape == ():
+        return _row_array_mask(csr, row)
+    else:
+        return _mr_matrix_mask(csr, row)
 
 
 def cs(csr, row):

--- a/csr/_wiring.py
+++ b/csr/_wiring.py
@@ -36,6 +36,14 @@ def _csr_row(csr, row):
             return _rows._mr_matrix_ones
 
 
+@overload_method(CSRType, 'row_mask')
+def _csr_row_mask(csr, row):
+    if isinstance(row, types.Integer):
+        return _rows._row_array_mask
+    elif isinstance(row, types.ArrayCompatible):
+        return _rows._mr_matrix_mask
+
+
 @overload_method(CSRType, 'row_cs')
 def _csr_row_cs(csr, row):
     return _rows.cs

--- a/csr/csr.py
+++ b/csr/csr.py
@@ -386,6 +386,23 @@ class CSR(_csr_base):
         row = np.asarray(row, dtype='i4')
         return _rows.row_array(self, row)
 
+    def row_mask(self, row):
+        """
+        Return a dense logical array indicating which columns are set in the row
+        (or rows).
+
+        Args:
+            row(int or numpy.ndarray): the row index or indices.
+
+        Returns:
+            numpy.ndarray:
+                the row, with ``True`` for columns that are set on this row.  If
+                ``row`` is an array or list of length :math:`k`, this is a matrix
+                of shape :math:`k \\times \\mathrm{ncols}`.
+        """
+        row = np.asarray(row, dtype='i4')
+        return _rows.row_mask(self, row)
+
     def row_extent(self, row):
         """
         Get the extent of a row in the underlying column index and value arrays.

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -82,13 +82,52 @@ def test_csr_row(csr):
 
 @csr_slow()
 @given(st.data(), csrs(st.integers(1, 100), st.integers(1, 100)))
-def test_csr_rows(data, csr):
+def test_csr_multi_rows(data, csr):
     smat = csr.to_scipy()
 
     rows = data.draw(st.lists(st.integers(0, csr.nrows - 1), max_size=csr.nrows, unique=True))
     row_arrs = csr.row(rows)
     other = smat[rows, :].toarray()
     assert np.all(row_arrs == other)
+
+
+@csr_slow()
+@given(st.data())
+def test_csr_rows(data):
+    "Test the row() method - row and multi_rows in one test (to demonstrate feasibility)"
+    csr = data.draw(csrs(st.integers(1, 100), st.integers(1, 100)))
+    smat = csr.to_scipy()
+
+    row_id = st.integers(0, csr.nrows - 1)
+    row_list = st.lists(row_id, max_size=csr.nrows, unique=True)
+    rows = data.draw(st.one_of(row_id, row_list))
+
+    row_arrs = csr.row(rows)
+    other = smat[rows, :].toarray()
+    assert np.all(row_arrs == other)
+
+
+@csr_slow()
+@given(st.data())
+def test_csr_row_mask(data):
+    csr = data.draw(csrs(st.integers(1, 100), st.integers(1, 100)))
+
+    row_id = st.integers(0, csr.nrows - 1)
+    row_list = st.lists(row_id, max_size=csr.nrows, unique=True)
+    rows = data.draw(st.one_of(row_id, row_list))
+
+    row_arrs = csr.row_mask(rows)
+    if isinstance(rows, list):
+        assert row_arrs.shape == (len(rows), csr.ncols)
+        for i, row in enumerate(rows):
+            sp, ep = csr.row_extent(row)
+            assert np.all(row_arrs[i, csr.row_cs(row)])
+            assert np.sum(row_arrs[i, :]) == ep - sp
+    else:
+        assert row_arrs.shape == (csr.ncols,)
+        sp, ep = csr.row_extent(rows)
+        assert np.all(row_arrs[csr.row_cs(rows)])
+        assert np.sum(row_arrs) == ep - sp
 
 
 def test_csr_sparse_row():

--- a/tests/test_numba.py
+++ b/tests/test_numba.py
@@ -83,12 +83,33 @@ def _rows(csr, rows):
 @given(st.data(), csrs())
 def test_csr_rows(data, csr):
     rows = data.draw(st.lists(st.integers(0, csr.nrows - 1), unique=True))
-    rows = np.asarray(rows, dtype='i4')
+    rows = np.asarray(rows, dtype=np.int32)
     cmat = csr.row(rows)
     nmat = _rows(csr, rows)
 
     assert nmat.shape == cmat.shape
     assert np.all(nmat == cmat)
+
+
+@njit
+def _row_mask(csr, rows):
+    return csr.row_mask(rows)
+
+
+@given(st.data(), csrs())
+def test_csr_row_mask(data, csr):
+    csr = data.draw(csrs(st.integers(1, 100), st.integers(1, 100)))
+
+    row_id = st.integers(0, csr.nrows - 1)
+    row_list = st.lists(row_id, unique=True)
+    rows = data.draw(st.one_of(row_id, row_list))
+    if isinstance(rows, list):
+        rows = np.asarray(rows, dtype=np.int32)
+
+    nr_mask = _row_mask(csr, rows)
+    cr_mask = csr.row_mask(rows)
+    assert nr_mask.shape == cr_mask.shape
+    assert np.all(nr_mask == cr_mask)
 
 
 @njit


### PR DESCRIPTION
This adds a `row_mask` method to the CSR class that returns a boolean array (or matrix) representing the sparsity structure of selected rows.