### PR TITLE
NEP 29: Require minimum versions Python 3.8 and NumPy 1.21

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,6 @@ jobs:
         - windows
         - ubuntu
         python:
-        - "3.7"
         - "3.8"
         - "3.9"
         - "3.10"
@@ -84,7 +83,6 @@ jobs:
       fail-fast: false
       matrix:
         python:
-        - "3.7"
         - "3.8"
         - "3.9"
         - "3.10"
@@ -131,7 +129,7 @@ jobs:
       - name: Set up Python and environment
         uses: lenskit/lkbuild/actions/setup-vanilla-env@main
         with:
-          python-version: "3.7"
+          python-version: "3.8"
           include-dev-dependencies: false
           extras: test
           constraints-file: min-constraints.txt

--- a/min-constraints.txt
+++ b/min-constraints.txt
@@ -1,6 +1,6 @@
 # constraints to install older supported versions of deps
 # core deps
-numpy==1.17.0
+numpy==1.21.0
 numba==0.51.0
 scipy==1.2.0
 

--- a/min-constraints.txt
+++ b/min-constraints.txt
@@ -2,7 +2,7 @@
 # core deps
 numpy==1.21.0
 numba==0.51.0
-scipy==1.2.0
+scipy==1.4.0
 
 # test deps
 pytest==6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,10 @@ description = "Compressed Sparse Row matrices for Python, with Numba API."
 readme = "README.md"
 license = { file = "LICENSE" }
 dynamic = ['version']
-requires-python = ">= 3.7"
+requires-python = ">= 3.8"
 dependencies = [
     "numba >=0.51,<0.57",
-    "numpy >=1.17",
+    "numpy >=1.21",
     "scipy >=1.2,<2"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requires-python = ">= 3.8"
 dependencies = [
     "numba >=0.51,<0.57",
     "numpy >=1.21",
-    "scipy >=1.2,<2"
+    "scipy >=1.4,<2"
 ]
 
 [[project.authors]]


### PR DESCRIPTION
This updates CSR for [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html), requiring Python 3.8 or later and NumPy 1.21 or later (closes #26).